### PR TITLE
userfields: correct FAU ID name

### DIFF
--- a/faufablab_custom_user_fields.php
+++ b/faufablab_custom_user_fields.php
@@ -8,7 +8,7 @@ defined('ABSPATH') or die("[!] This script must be executed by a wordpress insta
  */
 function faufablab_custom_contact_methods( $fields ) {
 	$fields['mobile'] = __( 'Mobile' );
-	$fields['fau_id'] = __( 'FAU ID' );
+	$fields['fau_id'] = __( 'FAU ID von Rückseite FAUcard' );
 	return $fields;
 }
 add_filter( 'user_contactmethods', 'faufablab_custom_contact_methods' );

--- a/faufablab_custom_user_fields.php
+++ b/faufablab_custom_user_fields.php
@@ -4,11 +4,11 @@
 defined('ABSPATH') or die("[!] This script must be executed by a wordpress instance!\r\n");
 
 /**
- * Add Mobile number and FAU Card ID Field to contact methods
+ * Add Mobile number and FAU ID Field to contact methods
  */
 function faufablab_custom_contact_methods( $fields ) {
 	$fields['mobile'] = __( 'Mobile' );
-	$fields['fau_id'] = __( 'FAU Card ID' );
+	$fields['fau_id'] = __( 'FAU ID' );
 	return $fields;
 }
 add_filter( 'user_contactmethods', 'faufablab_custom_contact_methods' );


### PR DESCRIPTION
FAU Card ID is named FAU ID on the Card it self.
This should improve the understanding which ID from FAU Card is needed for new users.